### PR TITLE
feat(walking): 누적 산책 통계 API 구현

### DIFF
--- a/app/api/walking.py
+++ b/app/api/walking.py
@@ -1,0 +1,77 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from app.database import get_db
+from app.models.user import User
+from app.models.walking_history import WalkingHistory
+from app.schemas.walking import WalkingStatsResponse
+from app.schemas.common import ApiResponse, success_response
+from app.utils.dependencies import get_current_user
+from app.utils.distance import calculate_carbon_saved
+
+router = APIRouter(prefix="/walking", tags=["walking"])
+
+#현재 user_id 기준으로 WalkingHistory를 조회해서 COOUT 및 SUM을 수행
+@router.get(
+    "/summary",
+    response_model=ApiResponse[WalkingStatsResponse],
+    summary="누적 산책 통계 조회",
+    description="사용자의 전체 산책 기록을 집계하여 총 산책 횟수, 완료 횟수, 누적 걸음 수, 누적 거리(km), 탄소 절감량(kg)을 반환합니다."
+)
+def get_walking_summary(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    누적 산책 통계 조회
+    - 집계 방식: 매 요청 시 WalkingHistory 테이블에서 SUM/COUNT 수행
+    """
+
+    # 1) 총 산책 횟수
+    total_walks = (
+        db.query(func.count(WalkingHistory.id))
+        .filter(WalkingHistory.user_id == current_user.id)
+        .scalar()
+        or 0
+    )
+
+    # 2) 완료된 산책 횟수
+    completed_walks = (
+        db.query(func.count(WalkingHistory.id))
+        .filter(
+            WalkingHistory.user_id == current_user.id,
+            WalkingHistory.is_completed.is_(True),
+        )
+        .scalar()
+        or 0
+    )
+
+    # 3) 누적 걸음 수, 누적 거리(m)
+    total_steps, total_distance_m = (
+        db.query(
+            func.coalesce(func.sum(WalkingHistory.steps), 0),
+            func.coalesce(func.sum(WalkingHistory.distance), 0),
+        )
+        .filter(WalkingHistory.user_id == current_user.id)
+        .one()
+    )
+
+    # distance는 m 단위이므로 km로 변환
+    total_distance_km = round(total_distance_m / 1000.0, 2) if total_distance_m else 0.0
+
+    # km -> 탄소 절감량(kg)
+    total_carbon_saved_kg = calculate_carbon_saved(total_distance_km)
+
+    stats_response = WalkingStatsResponse(
+        total_walks=total_walks,
+        completed_walks=completed_walks,
+        total_steps=total_steps,
+        total_distance_km=total_distance_km,
+        total_carbon_saved_kg=total_carbon_saved_kg,
+    )
+
+    return success_response(
+        data=stats_response,
+        message="누적 산책 통계 조회가 완료되었습니다.",
+    )

--- a/app/schemas/walking.py
+++ b/app/schemas/walking.py
@@ -31,3 +31,7 @@ class WalkingHistoryResponse(BaseModel):
 class WalkingStatsResponse(BaseModel):
     total_walks: int
     completed_walks: int
+    total_steps: int = 0
+    total_distance_km: float = 0.0
+    total_carbon_saved_kg: float = 0.0
+#기존 DTO 충돌 방지를 위해 total_walks, completed_walks 만 세팅해도 검증 에러 발생 X

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from fastapi.exceptions import RequestValidationError
 from jose.exceptions import JWTError, ExpiredSignatureError
 from app.database import Base, engine
 from app.models import *
-from app.api import auth, paths
+from app.api import auth, paths, walking
 from app.utils.exceptions import (
     custom_http_exception_handler,
     validation_exception_handler,
@@ -43,6 +43,7 @@ app.add_middleware(
 # Routers
 app.include_router(auth.router)
 app.include_router(paths.router)
+app.include_router(walking.router)
 
 
 # 앱 시작 시


### PR DESCRIPTION
## 연관 이슈
- Closes #9 

## 개요
사용자의 누적 산책 기록을 기반으로 총 걸음수, 총 거리(km), 총 탄소 절감량(kg)을 계산하여 반환하는 산책 집계 API를 구현했습니다.
관련 논문을 통해 탄소 배출량 산정 공식을 적용하여 보다 객관적인 수치를 제공하도록 반영했습니다.

## 주요 내용
1) 누적 산책 통계 API 구현: GET /walking/summary
응답 구조는 기존 프로젝트의 통일된 ApiResponse 형식 적용
반환 항목
- total_walks
- completed_walks
- total_steps
- total_distance_km
- total_carbon_saved_kg

2) 거리 및 탄소량 산정 공식 적용
논문: CLECAT Guide on Calculating GHG Emissions for Freight Forwarding and Logistics Services
- 핵심 적용 공식
걸음수 → 거리 변환
distance_m = steps × 0.7
distance_km = distance_m / 1000
거리 → 탄소 절감량 변환
CO₂_saved = distance_km × 0.21 kg/km
위 공식은 기존 교통수단 대비 걷기/자전거 이동 시 배출 저감효과 산정 방식과 동일합니다

3) ORM 및 스키마 구축 기반으로 집계 로직 추가
walking_histories 테이블 기반 집계
user_id 기준으로 그룹핑
SQLAlchemy ORM으로 총합/개수 산정 로직 구현

4) 공통 응답 템플릿(ApiResponse) 적용
isSuccess, code, httpStatus, message, data, timeStamp
기존 API와 완전 동일한 구조 유지

## 공유 사항
Walking End API 구현 시
steps / distance / is_completed 데이터 입력 시
summary 값이 자동 상승하는지 추가 테스트 예정

## 트러블슈팅
1) summary API 응답 구조 오류 (일반 dict 반환 문제)
최초 구현 시 반환 값이 FastAPI 기본 dict였으며
팀에서 사용하는 통일된 응답 구조(ApiResponse)와 맞지 않는 문제 발생.

- 해결
success_response() 유틸을 사용하여 모든 응답을 ApiResponse 형태로 래핑.
Swagger에서도 통일된 response model로 표시됨을 확인.

2) Carbon 계산 시 Float 정밀도 문제
Python float 연산 시 소수점 rounding 이슈 발생:
예: 0.7 * 1234 / 1000 계산 시 0.863799999999 형태로 출력됨.

- 해결
round(value, 2) 적용하여 소수점 2자리까지 변환

3) 탄소량 계산식 근거 부족 문제
첨부 논문(CLECAT Guide)의 이동수단 배출량 차이 기반 계산 공식을 분석하여
“대체 가능 교통수단 대비 저감효과” 방식이 타당함을 확인하고 PR에 공식 출처와 분석을 추가함.