### PR TITLE
feat(walking): 걷기 시작/끝 API 및 요약 통합 기능 추

### DIFF
--- a/app/api/walking.py
+++ b/app/api/walking.py
@@ -1,23 +1,165 @@
-from fastapi import APIRouter, Depends
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 
 from app.database import get_db
 from app.models.user import User
 from app.models.walking_history import WalkingHistory
-from app.schemas.walking import WalkingStatsResponse
-from app.schemas.common import ApiResponse, success_response
+from app.models.path import Path
+from app.schemas.walking import (
+    WalkingStart,
+    WalkingEnd,
+    WalkingSessionStartResponse,
+    WalkingHistoryResponse,
+    WalkingStatsResponse,
+)
+from app.schemas.common import ApiResponse, success_response, created_response
 from app.utils.dependencies import get_current_user
 from app.utils.distance import calculate_carbon_saved
 
 router = APIRouter(prefix="/walking", tags=["walking"])
 
-#현재 user_id 기준으로 WalkingHistory를 조회해서 COOUT 및 SUM을 수행
+
+@router.post(
+    "/start",
+    response_model=ApiResponse[WalkingSessionStartResponse],
+    status_code=status.HTTP_201_CREATED,
+    summary="산책 세션 시작",
+    description="산책 세션을 시작하고 sessionId를 발급합니다.",
+)
+def start_walking_session(
+    body: WalkingStart,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    산책 세션 시작
+    - WalkingHistory에 빈 세션(steps=0, duration=0, distance=0, is_completed=False) 생성
+    - 생성된 id를 session_id로 반환
+    """
+
+    # 안정성을 위해서 path 존재 여부 검증
+    path = db.query(Path).filter(Path.id == body.path_id).first()
+    if not path:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="산책 코스를 찾을 수 없습니다.",
+        )
+
+    new_history = WalkingHistory(
+        user_id=current_user.id,
+        path_id=body.path_id,
+        steps=0,
+        duration=0,
+        distance=0,
+        is_completed=False,
+        walked_at=datetime.utcnow(),
+    )
+
+    db.add(new_history)
+    db.commit()
+    db.refresh(new_history)
+
+    response = WalkingSessionStartResponse(
+        session_id=new_history.id,
+        path_id=new_history.path_id,
+    )
+
+    return created_response(
+        data=response,
+        message="산책 세션이 시작되었습니다.",
+    )
+
+
+@router.post(
+    "/{session_id}/end",
+    response_model=ApiResponse[WalkingHistoryResponse],
+    summary="산책 세션 종료",
+    description="걸음 수, 시간, 이동 거리, 완료 여부를 저장하고 사용자 누적 데이터를 업데이트합니다.",
+)
+def end_walking_session(
+    session_id: int,
+    body: WalkingEnd,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    산책 세션 종료
+    - 해당 세션에 steps, duration, distance, is_completed 업데이트
+    - User.total_steps, User.total_distance, User.carbon_saved 누적 업데이트
+    """
+
+    # 세션 조회 (본인 것만)
+    history = (
+        db.query(WalkingHistory)
+        .filter(
+            WalkingHistory.id == session_id,
+            WalkingHistory.user_id == current_user.id,
+        )
+        .first()
+    )
+
+    if not history:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="산책 세션을 찾을 수 없습니다.",
+        )
+
+    # Path 이름 사용을 위해 관계 접근
+    path = history.path
+    if not path:
+        path = db.query(Path).filter(Path.id == history.path_id).first()
+
+    # WalkingHistory 업데이트
+    history.steps = body.steps
+    history.duration = body.duration
+    history.distance = body.distance  # meters
+    history.is_completed = body.is_completed
+    history.walked_at = datetime.utcnow()
+
+    # User 누적 값 업데이트
+    user = current_user
+
+    # steps 누적
+    user.total_steps = (user.total_steps or 0) + body.steps
+
+    # distance 누적 (m -> km)
+    delta_distance_km = round(body.distance / 1000.0, 2)
+    user.total_distance = round((user.total_distance or 0.0) + delta_distance_km, 2)
+
+    # 탄소 절감량 누적 (거리 기반)
+    delta_carbon_kg = calculate_carbon_saved(delta_distance_km)
+    user.carbon_saved = round((user.carbon_saved or 0.0) + delta_carbon_kg, 2)
+
+    db.commit()
+    db.refresh(history)
+    db.refresh(user)
+
+    history_response = WalkingHistoryResponse(
+        id=history.id,
+        path_id=history.path_id,
+        path_name=path.name if path else "",
+        steps=history.steps,
+        duration=history.duration,
+        distance=history.distance,
+        is_completed=history.is_completed,
+        walked_at=history.walked_at,
+    )
+
+    return success_response(
+        data=history_response,
+        message="산책 세션이 종료되었습니다.",
+    )
+
+
+# 아래부터는 기존 summary API 그대로 유지
 @router.get(
     "/summary",
     response_model=ApiResponse[WalkingStatsResponse],
     summary="누적 산책 통계 조회",
-    description="사용자의 전체 산책 기록을 집계하여 총 산책 횟수, 완료 횟수, 누적 걸음 수, 누적 거리(km), 탄소 절감량(kg)을 반환합니다."
+    description="사용자의 전체 산책 기록을 집계하여 총 산책 횟수, 완료 횟수, 누적 걸음 수, 누적 거리(km), 탄소 절감량(kg)을 반환합니다.",
 )
 def get_walking_summary(
     current_user: User = Depends(get_current_user),

--- a/app/api/walking.py
+++ b/app/api/walking.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from decimal import Decimal
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
@@ -127,12 +128,14 @@ def end_walking_session(
 
     # distance 누적 (m -> km)
     delta_distance_km = round(body.distance / 1000.0, 2)
-    user.total_distance = round((user.total_distance or 0.0) + delta_distance_km, 2)
+    current_total_distance = float(user.total_distance or 0.0)
+    user.total_distance = round(current_total_distance + delta_distance_km, 2)
 
     # 탄소 절감량 누적 (거리 기반)
     delta_carbon_kg = calculate_carbon_saved(delta_distance_km)
-    user.carbon_saved = round((user.carbon_saved or 0.0) + delta_carbon_kg, 2)
-
+    current_carbon = float(user.carbon_saved or 0.0)
+    user.carbon_saved = round(current_carbon + delta_carbon_kg, 2)
+    
     db.commit()
     db.refresh(history)
     db.refresh(user)
@@ -199,9 +202,11 @@ def get_walking_summary(
         .one()
     )
 
-    # distance는 m 단위이므로 km로 변환
-    total_distance_km = round(total_distance_m / 1000.0, 2) if total_distance_m else 0.0
-
+    # 여기서 Decimal -> float 변환
+    # total_distance_m 이 Decimal일 수도 있고 int일 수도 있으니 float()으로 통일
+    distance_m_float = float(total_distance_m or 0)
+    total_distance_km = round(distance_m_float / 1000.0, 2) if distance_m_float > 0 else 0.0
+    
     # km -> 탄소 절감량(kg)
     total_carbon_saved_kg = calculate_carbon_saved(total_distance_km)
 

--- a/app/schemas/walking.py
+++ b/app/schemas/walking.py
@@ -13,6 +13,14 @@ class WalkingEnd(BaseModel):
     distance: int
     is_completed: bool
 
+class WalkingSessionStartResponse(BaseModel):
+    """
+    걷기 세션 시작 시 내려줄 응답
+    - session_id: WalkingHistory.id
+    - path_id: 어떤 코스를 걷는지
+    """
+    session_id: int
+    path_id: int
 
 class WalkingHistoryResponse(BaseModel):
     id: int


### PR DESCRIPTION
## 연관 이슈
- Closes #7 

## 개요
사용자가 산책을 시작하고 종료할 수 있는 걷기 세션 기능을 추가했습니다.
세션 종료 시 개별 기록(WalkingHistory)과 사용자 누적 데이터(User.total_steps / total_distance / carbon_saved)를 동시에 업데이트하고, 기존 누적 통계 API(summary)와도 일관되게 동작하도록 정리했습니다.

## 주요 내용
1. 걷기 세션 시작 API 추가 (POST /walking/start)
요청 바디: path_id를 포함한 WalkingStart DTO 사용

- WalkingHistory에 빈 세션 생성
기본값: steps=0, duration=0, distance=0, is_completed=False, walked_at=현재 시각
- user_id는 현재 로그인한 사용자 기준으로 저장
- 생성된 WalkingHistory.id를 session_id로 반환
- 응답: ApiResponse<WalkingSessionStartResponse> 형태로 session_id와 path_id 포함
- 공통 응답 스키마(ApiResponse)를 사용해 기존 API들과 응답 구조 일관성 유지

2. 걷기 세션 종료 API 추가 (POST /walking/{session_id}/end)
요청 경로: session_id(WalkingHistory id) Path Parameter
요청 바디: WalkingEnd DTO
path_id, steps, duration, distance, is_completed

- 해당 session_id + 현재 사용자 기준으로 WalkingHistory 조회
- 세션 정보 업데이트 steps, duration, distance(m 단위), is_completed, walked_at 갱신
- Path 정보와 조합해 응답용 WalkingHistoryResponse 생성
- 응답: ApiResponse<WalkingHistoryResponse>
- 코스 이름(path_name), 걸음 수, 소요 시간, 거리, 완료 여부, 기록 시각 포함

3. 사용자 누적 데이터 업데이트 로직 추가
세션 종료 API에서 아래 누적 필드 동시 갱신
- User.total_steps: 기존 값(or 0)에 이번 세션 steps를 더하는 방식으로 누적
- User.total_distance (km 단위 누적): 세션의 distance(m)를 km로 변환  후 delta_distance_km = distance(m) / 1000
user.total_distance += delta_distance_km
- User.carbon_saved (kg 단위 누적): CLECAT 가이드 기반 거리-탄소 환산 함수를 재사용
calculate_carbon_saved(distance_km) 결과를
user.carbon_saved += delta_carbon_kg 형태로 누적
- DB에서 가져온 값이 None이거나 Decimal일 수 있는 점을 고려해
누적 계산 전 float(user.total_distance or 0.0) / float(user.carbon_saved or 0.0)로 정규화

4. 누적 통계 API(GET /walking/summary)와의 정합성 유지
집계 기준: WalkingHistory 전체를 기준으로 COUNT / SUM 수행
total_walks: 사용자별 전체 세션 수
completed_walks: is_completed = True 인 세션 수
total_steps: sum(steps)
total_distance_km: sum(distance(m))을 km로 변환 후 소수 둘째 자리까지
total_carbon_saved_kg: 위 거리(km)에 탄소 절감량 계산 함수를 적용

- 응답은 ApiResponse<WalkingStatsResponse>로 통일
- DB 집계 결과를 기반으로 계산하므로 세션 종료 시점에 누적 필드를 업데이트하더라도 summary API와 실제 WalkingHistory 데이터가 일관된 값을 유지

## 트러블 슈팅
1) Decimal 타입으로 인한 summary API 500 오류
- 문제: MySQL의 SUM() 결과가 decimal.Decimal 타입으로 반환되며
total_distance_m / 1000.0 계산 시 Decimal + float 연산 오류 발생.
- 해결: float(total_distance_m or 0) 형태로 명시적 변환 후 계산하도록 수정.
- 결과: summary API 정상 동작 확인.

2) 세션 종료 후 누적 값(steps, distance, carbon) 반영 불일치
- 문제: User 누적 필드 업데이트에서 None 값 또는 Decimal 타입이 섞여 정합성 오류 발생 가능.
- 해결: 누적 계산 시 모든 User 필드를 float/0 기준으로 초기화 후 값 누적.
- 결과: 세션 종료 → summary 결과가 WalkingHistory 데이터와 일관되게 반영됨 확인.

3) end API 테스트 검증
- 문제: start/end/summary 호출 후 값 차이가 발생할 가능성.
- 해결: 동일 사용자로 직접 검증(코스 등록 → start → end → summary).
- 결과: 총 산책 횟수, 걸음수, 거리, 탄소 절감량이 예상값과 정확히 일치함 확인.