### PR TITLE
feat: 마이페이지 기능 구현

### DIFF
--- a/app/api/mypage.py
+++ b/app/api/mypage.py
@@ -1,0 +1,88 @@
+from fastapi import APIRouter, Depends, UploadFile, File, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.user import User
+from app.schemas.common import ApiResponse, success_response
+from app.schemas.user import (
+    UserProfileResponse,
+    UserNicknameUpdate,
+)
+from app.utils.dependencies import get_current_user
+from app.utils.s3 import upload_image_to_s3, delete_image_from_s3
+
+router = APIRouter(prefix="/mypage", tags=["mypage"])
+
+
+# -----------------------------------
+# 1) 프로필 조회 API
+# -----------------------------------
+@router.get(
+    "/profile",
+    response_model=ApiResponse[UserProfileResponse],
+    summary="마이페이지 프로필 조회",
+    description="사용자 정보(닉네임, 프로필 이미지, 걸음수, 거리, 탄소 절감량 등)를 조회합니다."
+)
+def get_profile(
+    current_user: User = Depends(get_current_user)
+):
+    user_profile = UserProfileResponse.from_orm(current_user)
+    return success_response(data=user_profile, message="프로필 조회가 완료되었습니다.")
+
+
+# -----------------------------------
+# 2) 닉네임 변경 API
+# -----------------------------------
+@router.patch(
+    "/nickname",
+    response_model=ApiResponse[UserProfileResponse],
+    summary="닉네임 변경",
+    description="사용자의 닉네임을 변경합니다."
+)
+def update_nickname(
+    payload: UserNicknameUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    current_user.nickname = payload.nickname
+    db.commit()
+    db.refresh(current_user)
+
+    return success_response(
+        data=UserProfileResponse.from_orm(current_user),
+        message="닉네임이 성공적으로 변경되었습니다."
+    )
+
+
+# -----------------------------------
+# 3) 프로필 이미지 변경 API
+# -----------------------------------
+@router.patch(
+    "/profile-image",
+    response_model=ApiResponse[UserProfileResponse],
+    summary="프로필 이미지 변경",
+    description="사용자의 프로필 이미지를 변경합니다. 기존 이미지가 있을 경우 S3에서 삭제합니다."
+)
+async def update_profile_image(
+    image: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    # 기존 이미지 삭제 (default 이미지면 삭제 X)
+    if current_user.profile_image and current_user.profile_image != "default_profile.png":
+        try:
+            await delete_image_from_s3(current_user.profile_image)
+        except:
+            pass
+
+    # 새 이미지 업로드
+    new_image_url = await upload_image_to_s3(image, folder=f"profiles/{current_user.id}")
+
+    current_user.profile_image = new_image_url
+    db.commit()
+    db.refresh(current_user)
+
+    return success_response(
+        data=UserProfileResponse.from_orm(current_user),
+        message="프로필 이미지가 성공적으로 변경되었습니다."
+    )

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -48,3 +48,24 @@ class Token(BaseModel):
 
 class TokenData(BaseModel):
     email: Optional[str] = None
+
+class UserProfileResponse(BaseModel):
+    id: int
+    email: EmailStr
+    nickname: Optional[str]
+    profile_image: str
+    total_steps: int
+    total_distance: float
+    carbon_saved: float
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class UserNicknameUpdate(BaseModel):
+    nickname: str = Field(..., min_length=1, max_length=50)
+
+
+class UserProfileImageUpdate(BaseModel):
+    profile_image: str

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from fastapi.exceptions import RequestValidationError
 from jose.exceptions import JWTError, ExpiredSignatureError
 from app.database import Base, engine
 from app.models import *
-from app.api import auth, paths, walking
+from app.api import auth, paths, walking, mypage
 from app.utils.exceptions import (
     custom_http_exception_handler,
     validation_exception_handler,
@@ -44,6 +44,7 @@ app.add_middleware(
 app.include_router(auth.router)
 app.include_router(paths.router)
 app.include_router(walking.router)
+app.include_router(mypage.router)
 
 
 # 앱 시작 시


### PR DESCRIPTION
## 연관 이슈
- Closes #8 

## 개요
사용자 정보 조회 및 수정 기능을 제공하는 마이페이지 기능을 구현했습니다.  
프로필 조회, 닉네임 변경, 프로필 이미지 변경, 누적 걸음수·거리·탄소 절감량 조회를 포함합니다.

## 주요 내용
- `/mypage/profile`  
  - 로그인한 사용자의 프로필 정보 조회 API 구현  
  - 이메일, 닉네임, 프로필 이미지, 총 걸음수, 총 거리(km), 탄소 절감량(kg), 가입일자 반환
- `/mypage/nickname`  
  - 닉네임 변경 API 구현(PATCH)  
  - 입력 검증 및 DB 반영
- `/mypage/profile-image`  
  - S3 업로드 기반 프로필 이미지 수정 기능 구현  
  - 기존 이미지 삭제 처리 조건 추가(`default_profile.png`는 삭제 제외)
- 누적 정보 연동  
  - User 모델의 `total_steps`, `total_distance`, `carbon_saved`를 마이페이지 응답에 포함

## 공유 사항
- 모든 응답 스펙은 `ApiResponse` 공통 구조로 통일되었습니다.  
- Swagger에서 마이페이지 관련 API 문서가 자동 업데이트되었습니다.  
- 이미지 업로드 시 허용 확장자 및 파일 크기 제한 검증이 포함됩니다.

## 트러블 슈팅
- S3 삭제 시 기본 이미지가 삭제되지 않도록 조건 분기 추가  
- 이미지 업로드 실패가 전체 요청을 중단하지 않도록 예외 처리 보완  
- 누적 정보 조회 시 Decimal 타입 연산 오류 방지를 위해 float 변환 일괄 적용