### PR TITLE
fix: 회원가입/로그인 nickname 입력 구조 개선

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -19,7 +19,7 @@ router = APIRouter(prefix="/auth", tags=["auth"])
     response_model=ApiResponse[UserResponse],
     status_code=status.HTTP_201_CREATED,
     summary="회원가입",
-    description="이메일 중복 검사 및 비밀번호 유효성 검사 (영문, 숫자 포함 8자리 이상)"
+    description="이메일 중복 검사, 닉네임 입력, 비밀번호 유효성 검사 (영문, 숫자 포함 8자리 이상)"
 )
 def signup(user_data: UserSignup, db: Session = Depends(get_db)):
     # 이메일 중복 검사
@@ -42,6 +42,7 @@ def signup(user_data: UserSignup, db: Session = Depends(get_db)):
     new_user = User(
         email=user_data.email,
         password=hashed_password,
+        nickname=user_data.nickname,
         profile_image="default_profile.png"
     )
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -6,12 +6,12 @@ from datetime import datetime
 class UserSignup(BaseModel):
     email: EmailStr
     password: str = Field(..., min_length=8, description="영문, 숫자 포함 8자리 이상")
-
+    nickname: Optional[str] = Field(None, min_length=1, max_length=50)
 
 class UserLogin(BaseModel):
     email: EmailStr
     password: str
-
+    nickname: Optional[str] = None  # 로그인 시에도 nickname을 받을 수 있게 대응 (실제 사용 X)
 
 class UserResponse(BaseModel):
     id: int
@@ -44,7 +44,6 @@ class CarbonInfo(BaseModel):
 class Token(BaseModel):
     access_token: str
     token_type: str
-
 
 class TokenData(BaseModel):
     email: Optional[str] = None


### PR DESCRIPTION
## 연관 이슈
- Closes #13 

## 개요
회원가입 및 로그인 요청에서 nickname을 입력받아 User.nickname 필드에 저장하도록 구조를 개선했습니다.  
기존 인증 로직과 충돌하지 않도록 스키마 및 API 전체 흐름을 정리했습니다.

## 주요 내용
- UserSignup 스키마에 `nickname: Optional[str]` 추가  
- UserLogin 스키마에도 nickname 필드 추가(optional)  
- 회원가입 시 전달된 nickname을 User.nickname 컬럼에 저장하도록 로직 개선  
- 로그인은 nickname 없이도 정상 동작하도록 기존 인증 흐름 유지  
- Swagger 자동 문서에 nickname 스펙이 반영되도록 스키마 정리

## 공유 사항
- nickname 필드는 선택 입력값이며, 회원가입 시에만 실제 저장에 사용됩니다.  
- 로그인 요청에서는 nickname을 입력해도 인증에는 사용되지 않습니다.  
- 마이페이지 프로필 조회(`/mypage/profile`)에서 nickname이 정상적으로 노출됩니다.

## 트러블 슈팅
- nickname 없이 회원가입 시 KeyError 방지를 위해 optional 필드로 처리  
- 기존 UserResponse에 nickname 필드가 누락된 경우 응답 스키마 불일치 해결  
- Swagger 문서 필드 불일치 문제를 스키마 기반 자동 업데이트로 통일