### PR TITLE
feat(path): 좋아요 토글 기능 및 좋아요한 코스 목록 조회 API 구현

### DIFF
--- a/app/api/paths.py
+++ b/app/api/paths.py
@@ -13,6 +13,7 @@ from app.schemas.path import (
     PathImageResponse,
     FilterEnum,
     SortEnum,
+    PathLikeStatusResponse,
 )
 from app.schemas.common import ApiResponse, created_response, success_response
 from app.utils.dependencies import get_current_user
@@ -246,3 +247,113 @@ def get_path_detail(
     )
 
     return success_response(data=path_detail, message="산책 코스 상세 조회가 완료되었습니다.")
+
+@router.post(
+    "/{path_id}/like-toggle",
+    response_model=ApiResponse[PathLikeStatusResponse],
+    summary="산책 코스 좋아요 토글",
+    description="이미 좋아요한 코스면 좋아요를 취소하고, 아니라면 좋아요를 등록합니다."
+)
+
+def toggle_path_like(
+    path_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    # 코스 존재 여부 확인
+    path = db.query(Path).filter(Path.id == path_id).first()
+    if not path:
+        raise HTTPException(status_code=404, detail="코스를 찾을 수 없습니다")
+
+    # 기존 좋아요 있는지 확인
+    existing_like = db.query(Like).filter(
+        Like.user_id == current_user.id,
+        Like.path_id == path_id
+    ).first()
+
+    # 좋아요가 이미 있으면 → 취소
+    if existing_like:
+        db.delete(existing_like)
+        # likes_count 감소 (0 아래로 내려가지 않게 보호)
+        path.likes_count = max(0, (path.likes_count or 0) - 1)
+        is_liked = False
+        message = "좋아요가 취소되었습니다."
+    else:
+        # 없으면 → 새로 등록
+        new_like = Like(user_id=current_user.id, path_id=path_id)
+        db.add(new_like)
+        path.likes_count = (path.likes_count or 0) + 1
+        is_liked = True
+        message = "좋아요가 등록되었습니다."
+
+    db.commit()
+    db.refresh(path)
+
+    like_status = PathLikeStatusResponse(
+        path_id=path.id,
+        is_liked=is_liked,
+        likes_count=path.likes_count or 0
+    )
+
+    return success_response(
+        data=like_status,
+        message=message
+    )
+    
+@router.get(
+    "/likes",
+    response_model=ApiResponse[List[PathListResponse]],
+    summary="좋아요한 산책 코스 목록 조회",
+    description="사용자가 좋아요한 산책 코스만 모아 조회합니다."
+)
+def get_liked_paths(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    현재 로그인한 사용자가 좋아요한 산책 코스 목록을 반환
+    - PathListResponse 포맷을 재사용
+    - is_liked는 항상 True
+    """
+
+    # 좋아요한 path_id 목록
+    liked_path_ids_subquery = (
+        db.query(Like.path_id)
+        .filter(Like.user_id == current_user.id)
+        .subquery()
+    )
+
+    # 해당 path들만 조회
+    paths = (
+        db.query(Path)
+        .filter(Path.id.in_(liked_path_ids_subquery))
+        .order_by(Path.created_at.desc())
+        .all()
+    )
+
+    result = []
+    for path in paths:
+        # 대표 이미지 찾기
+        representative_image = db.query(PathImage).filter(
+            PathImage.path_id == path.id,
+            PathImage.is_representative == 1
+        ).first()
+
+        # 태그 목록
+        tags = [tag.tag_name for tag in path.tags]
+
+        result.append(PathListResponse(
+            id=path.id,
+            name=path.name,
+            representative_image=representative_image.image_url if representative_image else None,
+            estimated_time=path.estimated_time,
+            distance=path.distance,
+            likes_count=path.likes_count,
+            tags=tags,
+            is_liked=True  # ✅ 좋아요 목록이므로 항상 True
+        ))
+
+    return success_response(
+        data=result,
+        message="좋아요한 산책 코스 목록 조회가 완료되었습니다."
+    )

--- a/app/api/paths.py
+++ b/app/api/paths.py
@@ -192,62 +192,6 @@ def get_paths(
 
     return success_response(data=result, message="산책 코스 목록 조회가 완료되었습니다.")
 
-
-@router.get(
-    "/{path_id}",
-    response_model=ApiResponse[PathDetailResponse],
-    summary="산책 코스 상세 조회",
-    description="전체 이미지, 코스 타입, 좋아요 여부 포함"
-)
-def get_path_detail(
-    path_id: int,
-    current_user: Optional[User] = Depends(get_current_user),
-    db: Session = Depends(get_db)
-):
-    path = db.query(Path).filter(Path.id == path_id).first()
-    if not path:
-        raise HTTPException(status_code=404, detail="코스를 찾을 수 없습니다")
-
-    # 좋아요 여부 확인
-    is_liked = False
-    if current_user:
-        like = db.query(Like).filter(
-            Like.user_id == current_user.id,
-            Like.path_id == path_id
-        ).first()
-        is_liked = like is not None
-
-    # 이미지 목록
-    images = [PathImageResponse(
-        id=img.id,
-        image_url=img.image_url,
-        is_representative=bool(img.is_representative)
-    ) for img in path.images]
-
-    # 종류 (감성길, 씨티뷰길, 자연길, 야경길, 안전길만 필터링)
-    path_type_list = ["감성길", "씨티뷰길", "자연길", "야경길", "안전길"]
-    path_types = [tag.tag_name for tag in path.tags if tag.tag_name in path_type_list]
-
-    # 날짜 포맷 변환 (yyyy.mm.dd)
-    created_at_str = path.created_at.strftime("%Y.%m.%d")
-
-    path_detail = PathDetailResponse(
-        id=path.id,
-        name=path.name,
-        start_location=path.start_location,
-        end_location=path.end_location,
-        introduction=path.introduction,
-        estimated_time=path.estimated_time,
-        distance=path.distance,
-        likes_count=path.likes_count,
-        created_at=created_at_str,
-        images=images,
-        path_types=path_types,
-        is_liked=is_liked
-    )
-
-    return success_response(data=path_detail, message="산책 코스 상세 조회가 완료되었습니다.")
-
 @router.post(
     "/{path_id}/like-toggle",
     response_model=ApiResponse[PathLikeStatusResponse],
@@ -357,3 +301,58 @@ def get_liked_paths(
         data=result,
         message="좋아요한 산책 코스 목록 조회가 완료되었습니다."
     )
+
+@router.get(
+    "/{path_id}",
+    response_model=ApiResponse[PathDetailResponse],
+    summary="산책 코스 상세 조회",
+    description="전체 이미지, 코스 타입, 좋아요 여부 포함"
+)
+def get_path_detail(
+    path_id: int,
+    current_user: Optional[User] = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    path = db.query(Path).filter(Path.id == path_id).first()
+    if not path:
+        raise HTTPException(status_code=404, detail="코스를 찾을 수 없습니다")
+
+    # 좋아요 여부 확인
+    is_liked = False
+    if current_user:
+        like = db.query(Like).filter(
+            Like.user_id == current_user.id,
+            Like.path_id == path_id
+        ).first()
+        is_liked = like is not None
+
+    # 이미지 목록
+    images = [PathImageResponse(
+        id=img.id,
+        image_url=img.image_url,
+        is_representative=bool(img.is_representative)
+    ) for img in path.images]
+
+    # 종류 (감성길, 씨티뷰길, 자연길, 야경길, 안전길만 필터링)
+    path_type_list = ["감성길", "씨티뷰길", "자연길", "야경길", "안전길"]
+    path_types = [tag.tag_name for tag in path.tags if tag.tag_name in path_type_list]
+
+    # 날짜 포맷 변환 (yyyy.mm.dd)
+    created_at_str = path.created_at.strftime("%Y.%m.%d")
+
+    path_detail = PathDetailResponse(
+        id=path.id,
+        name=path.name,
+        start_location=path.start_location,
+        end_location=path.end_location,
+        introduction=path.introduction,
+        estimated_time=path.estimated_time,
+        distance=path.distance,
+        likes_count=path.likes_count,
+        created_at=created_at_str,
+        images=images,
+        path_types=path_types,
+        is_liked=is_liked
+    )
+
+    return success_response(data=path_detail, message="산책 코스 상세 조회가 완료되었습니다.")

--- a/app/schemas/path.py
+++ b/app/schemas/path.py
@@ -100,3 +100,11 @@ class PathDetailResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+class PathLikeStatusResponse(BaseModel):
+    path_id: int
+    is_liked: bool
+    likes_count: int
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
## 연관 이슈
- Closes #6 

## 개요
사용자가 산책 코스를 좋아요하거나 취소할 수 있도록 toggle 기능을 구현했습니다.
또한 사용자가 좋아요한 코스만 조회할 수 있도록 `/paths/likes` API를 추가했습니다.

## 주요 내용
- 좋아요 등록/취소 toggle API 추가 (`POST /paths/{path_id}/like-toggle`)
- Path.likes_count 증가/감소 로직 적용
- UniqueConstraint 기반 중복 좋아요 방지
- 좋아요한 코스 목록 조회 API 추가 (`GET /paths/likes`)
- PathList / PathDetail에 좋아요 여부(`is_liked`) 반영
- 라우팅 구조 정리 (정적 경로 우선 매칭)

## 공유 사항
- 좋아요 여부는 `Like` 테이블 존재 여부로 판단
- likes_count는 트랜잭션 내에서 정확한 증가/감소가 보장됨
- `/paths/likes`는 인증이 필요한 엔드포인트

## 트러블 슈팅
### 1) `/paths/likes` 호출 시 422 Unprocessable Content 발생
**증상**
- `GET /paths/likes` 요청 시 FastAPI가 `/likes`를 `path_id="likes"`로 잘못 매칭하여 int 변환 실패
- 서버 응답:
  ```
  "message": "path -> path_id: Input should be a valid integer"
  ```

**원인**
- FastAPI는 라우터를 위→아래 순서로 매칭함
- `/paths/{path_id}`가 `/paths/likes`보다 먼저 선언되어 있었고
  이로 인해 `/likes`가 동적 경로로 인식됨

**해결**
- 정적 경로(`/likes`)를 동적 경로(`/{path_id}`) **보다 위에 위치**하도록 수정
  ```diff
  + @router.get("/likes", ...)
  @router.get("/{path_id}", ...)
  ```

**결과**
- `/paths/likes` 정상 매칭 및 좋아요한 코스 목록 정상 반환 확인

